### PR TITLE
Solved bug in border color. Implemented STIC screen disable.

### DIFF
--- a/src/cart.c
+++ b/src/cart.c
@@ -68,12 +68,12 @@ int LoadCart(const char *path)
             printf("[ERROR] [FREEINTV] Cartridge load error indicator set\n");
         }
         
-		OSD_drawText(8, 4, "SIZE:");
-		OSD_drawInt(14, 4, size, 10);
+		OSD_drawText(8, 7, "SIZE:");
+		OSD_drawInt(14, 7, size, 10);
 
         if(isIntellicart()) // intellicart format
         {
-			OSD_drawText(8, 4, "INTELLICART");
+			OSD_drawText(8, 8, "INTELLICART");
             printf("[INFO] [FREEINTV] Intellicart cartridge format detected\n");		
             return loadIntellicart();
         }
@@ -81,8 +81,8 @@ int LoadCart(const char *path)
         {
 			if(isROM())
 			{
-				OSD_drawText(8, 4, "INTELLICART");
-				OSD_drawText(8, 5, "MISSING A8!");
+				OSD_drawText(8, 8, "INTELLICART");
+				OSD_drawText(8, 9, "MISSING A8!");
 				printf("[INFO] [FREEINTV] Possible Intellicart cartridge format detected\n");
 				return loadROM();
 			}

--- a/src/cp1610.c
+++ b/src/cp1610.c
@@ -187,7 +187,15 @@ int CP1610Tick(int debug)
 	return ticks;
 }
 
-int HLT(int v)  { return 0; } // Halt
+int HLT(int v)
+{
+    // Halt Instruction found! //
+    printf("\n\n[ERROR] [FREEINTV] HALT!\n");
+  
+    R[PC]--; // Repeat instruction forever instead of exiting without warning
+    return 0;
+}
+
 int SDBD(int v) { Flag_DoubleByteData = 1; return 4; } // Set Double Byte Data
 int EIS(int v)  { Flag_InteruptEnable = 1; return 4; } // Enable Interrupt System
 int DIS(int v)  { Flag_InteruptEnable = 0; return 4; } // Disable Interrupt System

--- a/src/intv.h
+++ b/src/intv.h
@@ -17,7 +17,9 @@
 	along with FreeIntv.  If not, see http://www.gnu.org/licenses/
 */
 
-extern int SR1; // SR1 line for interupt
+extern int SR1; // SR1 line for interrupt
+
+extern int intv_halt;
 
 void LoadGame(const char *path);
 

--- a/src/libretro.c
+++ b/src/libretro.c
@@ -315,6 +315,8 @@ void retro_run(void)
 		}
 	}
 
+    if (intv_halt)
+        OSD_drawTextBG(3, 5, "INTELLIVISION HALTED");
 	// send frame to libretro
 	Video(frame, frameWidth, frameHeight, sizeof(unsigned int) * frameWidth);
 

--- a/src/stic.h
+++ b/src/stic.h
@@ -31,7 +31,7 @@ extern int DisplayEnabled; // determines if frame should be updated or not
 
 extern unsigned int frame[352*224]; // frame buffer
 
-void STICDrawFrame(void);
+void STICDrawFrame(int);
 void STICReset(void);
 
 #endif


### PR DESCRIPTION
Also:
* Shows explanation if GROM and EXEC are missing.
* HALT and undefined instructions shows a message instead of exiting.
* Corrected position of messages for cartridge load.