### PR TITLE
Added Save States support (retro_serialize / retro_unserialize)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ FreeIntv is a libretro emulation core for the Mattel Intellivision designed to b
 ## Authors
 
 FreeIntv was created by David Richardson.
-The PSG and STIC emulation was made closer to hardware and optimized by Oscar Toledo G. (nanochess)
+The PSG and STIC emulation was made closer to hardware and optimized by Oscar Toledo G. (nanochess), who also added save states.
 
 ## License
 The FreeIntv core is licensed under GPLv3. More information at https://github.com/markwkidd/FreeIntv/blob/master/LICENSE.

--- a/src/cp1610.c
+++ b/src/cp1610.c
@@ -42,6 +42,28 @@ int Flag_Sign = 0;
 int Flag_Zero = 0;
 int Flag_Overflow = 0;
 
+void CP1610Serialize(struct CP1610serialized *all)
+{
+    all->Flag_DoubleByteData = Flag_DoubleByteData;
+    all->Flag_InteruptEnable = Flag_InteruptEnable;
+    all->Flag_Carry = Flag_Carry;
+    all->Flag_Sign = Flag_Sign;
+    all->Flag_Zero = Flag_Zero;
+    all->Flag_Overflow = Flag_Overflow;
+    memcpy(&all->R[0], &R[0], sizeof(R));
+}
+
+void CP1610Unserialize(const struct CP1610serialized *all)
+{
+    Flag_DoubleByteData = all->Flag_DoubleByteData;
+    Flag_InteruptEnable = all->Flag_InteruptEnable;
+    Flag_Carry = all->Flag_Carry;
+    Flag_Sign = all->Flag_Sign;
+    Flag_Zero = all->Flag_Zero;
+    Flag_Overflow = all->Flag_Overflow;
+    memcpy(&R[0], &all->R[0], sizeof(R));
+}
+
 void CP1610Reset()
 {
 	Flag_DoubleByteData = 0;

--- a/src/cp1610.h
+++ b/src/cp1610.h
@@ -17,6 +17,19 @@
 	along with FreeIntv.  If not, see http://www.gnu.org/licenses/
 */
 
+struct CP1610serialized {
+    int Flag_DoubleByteData;
+    int Flag_InteruptEnable;
+    int Flag_Carry;
+    int Flag_Sign;
+    int Flag_Zero;
+    int Flag_Overflow;
+    unsigned int R[8];
+};
+
+void CP1610Serialize(struct CP1610serialized *);
+void CP1610Unserialize(const struct CP1610serialized *);
+
 void CP1610Init(void); // Adds opcodes to lookup tables
 
 void CP1610Reset(void); // reset cpu

--- a/src/stic.c
+++ b/src/stic.c
@@ -54,7 +54,6 @@ int extendTop = 0;
 int extendLeft = 0;
 
 unsigned int CSP; // Color Stack Pointer
-unsigned int cscolors[4]; // color squares colors
 unsigned int fgcard[20]; // cached colors for cards on current row
 unsigned int bgcard[20]; // (used for normal color stack mode)
 #if defined(ABGR1555)
@@ -120,6 +119,42 @@ int reverse[256] = // lookup table to reverse the bits in a byte //
 	0x07, 0x87, 0x47, 0xC7, 0x27, 0xA7, 0x67, 0xE7, 0x17, 0x97, 0x57, 0xD7, 0x37, 0xB7, 0x77, 0xF7,
 	0x0F, 0x8F, 0x4F, 0xCF, 0x2F, 0xAF, 0x6F, 0xEF, 0x1F, 0x9F, 0x5F, 0xDF, 0x3F, 0xBF, 0x7F, 0xFF
 };
+
+void STICSerialize(struct STICserialized *all)
+{
+    all->STICMode = STICMode;
+    all->stic_phase = stic_phase;
+    all->stic_vid_enable = stic_vid_enable;
+    all->stic_reg = stic_reg;
+    all->stic_gram = stic_gram;
+    all->phase_len = phase_len;
+    all->DisplayEnabled = DisplayEnabled;
+    all->delayH = delayH;
+    all->delayV = delayV;
+    all->extendTop = extendTop;
+    all->extendLeft = extendLeft;
+    all->CSP = CSP;
+    memcpy(all->fgcard, fgcard, sizeof(fgcard));
+    memcpy(all->bgcard, bgcard, sizeof(bgcard));
+}
+
+void STICUnserialize(const struct STICserialized *all)
+{
+    STICMode = all->STICMode;
+    stic_phase = all->stic_phase;
+    stic_vid_enable = all->stic_vid_enable;
+    stic_reg = all->stic_reg;
+    stic_gram = all->stic_gram;
+    phase_len = all->phase_len;
+    DisplayEnabled = all->DisplayEnabled;
+    delayH = all->delayH;
+    delayV = all->delayV;
+    extendTop = all->extendTop;
+    extendLeft = all->extendLeft;
+    CSP = all->CSP;
+    memcpy(fgcard, all->fgcard, sizeof(fgcard));
+    memcpy(bgcard, all->bgcard, sizeof(bgcard));
+}
 
 void STICReset(void)
 {

--- a/src/stic.h
+++ b/src/stic.h
@@ -31,6 +31,31 @@ extern int DisplayEnabled; // determines if frame should be updated or not
 
 extern unsigned int frame[352*224]; // frame buffer
 
+struct STICserialized {
+    unsigned int STICMode;
+
+    int stic_phase;
+    int stic_vid_enable;
+    int stic_reg;
+    int stic_gram;
+    int phase_len;
+
+    int DisplayEnabled;
+
+    int delayH;
+    int delayV;
+
+    int extendTop;
+    int extendLeft;
+
+    unsigned int CSP;
+    unsigned int fgcard[20];
+    unsigned int bgcard[20];
+};
+
+void STICSerialize(struct STICserialized *);
+void STICUnserialize(const struct STICserialized *);
+
 void STICDrawFrame(int);
 void STICReset(void);
 


### PR DESCRIPTION
It works just fine with Leprechaun's Flight (homebrew) and Advanced Dungeon & Dragons: Cloudy Mountain (it certainly makes easier to defeat big monsters).