### PR TITLE
Serialization now can work anytime. Rewind working. RetroArch Restart option now works.

### DIFF
--- a/src/intv.c
+++ b/src/intv.c
@@ -100,15 +100,14 @@ void Reset()
 	SR1 = 0;
     intv_halt = 0;
 	CP1610Reset();
-	MemoryInit();
 	STICReset();
-	PSGInit();
 }
 
 void Init()
 {
 	CP1610Init();
 	MemoryInit();
+    PSGInit();
 }
 
 void Run()

--- a/src/libretro.c
+++ b/src/libretro.c
@@ -388,12 +388,13 @@ RETRO_API size_t retro_get_memory_size(unsigned id)
 	return 0;
 }
 
-#define SERIALIZED_VERSION 0x4f544700
+#define SERIALIZED_VERSION 0x4f544701
 
 struct serialized {
     int version;
     struct CP1610serialized CP1610;
     struct STICserialized STIC;
+    struct PSGserialized PSG;
     unsigned int Memory[0x10000];   // Should be equal to Memory.c
     // Extra variables from intv.c
     int SR1;
@@ -413,6 +414,7 @@ bool retro_serialize(void *data, size_t size)
     all->version = SERIALIZED_VERSION;
     CP1610Serialize(&all->CP1610);
     STICSerialize(&all->STIC);
+    PSGSerialize(&all->PSG);
     memcpy(all->Memory, Memory, sizeof(Memory));
     all->SR1 = SR1;
     all->intv_halt = intv_halt;
@@ -428,13 +430,10 @@ bool retro_unserialize(const void *data, size_t size)
         return false;
     CP1610Unserialize(&all->CP1610);
     STICUnserialize(&all->STIC);
+    PSGUnserialize(&all->PSG);
     memcpy(Memory, all->Memory, sizeof(Memory));
     SR1 = all->SR1;
     intv_halt = all->intv_halt;
-    PSGInit();
-    PSGFrame();
-    audioBufferPos = 0.0;
-    audioInc = 1;
     return true;
 }
 

--- a/src/psg.c
+++ b/src/psg.c
@@ -20,16 +20,43 @@
 #include "psg.h"
 #include "memory.h"
 
+int Volume[16] = { 0, 92, 128, 192, 256, 384, 512, 768, 1024, 1536, 2048, 3072, 4096, 6144, 8192, 10922 };
+
+int Envelope_Shift[4] = {8, 2, 1, 0};
+
+// Volume levels assigned to each channel from PSG registers
+#define VolA    (Memory[0x01FB] & 0x0F)
+#define VolB    (Memory[0x01FC] & 0x0F)
+#define VolC    (Memory[0x01FD] & 0x0F)
+
+// Envelope shifts for channels (6-bit variations only)
+#define EnvA    ((Memory[0x01FB] >> 4) & 0x03)
+#define EnvB    ((Memory[0x01FC] >> 4) & 0x03)
+#define EnvC    ((Memory[0x01FD] >> 4) & 0x03)
+
+int NoiseP; // Noise Period
+
+// Detect Tone enabled for this channel (0- enabled, 1- disabled)
+#define ToneA   ((Memory[0x01F8] & 0x01) != 0)
+#define ToneB   ((Memory[0x01F8] & 0x02) != 0)
+#define ToneC   ((Memory[0x01F8] & 0x04) != 0)
+           
+// Detect Noise enabled for this channel (0- enabled, 1- disabled)
+#define NoiseA  ((Memory[0x01F8] & 0x08) != 0)
+#define NoiseB  ((Memory[0x01F8] & 0x10) != 0)
+#define NoiseC  ((Memory[0x01F8] & 0x20) != 0)
+
+// Envelope type
+#define EnvFlags    (Memory[0x01FA] & 0x0F)
+
 int PSGBufferSize;
 int16_t PSGBuffer[7467];
 int PSGBufferPos;
 
-int Volume[16] = { 0, 92, 128, 192, 256, 384, 512, 768, 1024, 1536, 2048, 3072, 4096, 6144, 8192, 10922 };
-
 int Ticks; // CPU cycles not yet processed
 
 int CountA; // countdowns for tone generators
-int CountB; // used to modulate square-wave 
+int CountB; // used to modulate square-wave
 int CountC; // according to Channel Period
 int CountN; // countdown for noise generator
 int CountE; // countdown for envelope generator
@@ -41,28 +68,10 @@ int OutN;  // Noise generator output
 int OutE;  // Envelope generator output
 
 int ChA; // Channel Period from PSG Registers
-int ChB; 
-int ChC; 
-           
-int VolA; // volume levels assigned to each Channel from PSG Registers
-int VolB; 
-int VolC; 
-           
-int NoiseP; // Noise Period
-int NoiseA; // is Noise enabled for this channel
-int NoiseB; // 0 - enabled 
-int NoiseC;	// 1 - disabled
+int ChB;
+int ChC;
 
-           
-int ToneA; // is Tone enabled for this channel
-int ToneB; // 0 - enabled
-int ToneC; // 1 - disabled
-           
-int EnvP;    // Envelope Period 
-int EnvFlags; // Envelope Type
-int EnvA;    // Envelope Shifts for Channels (6-bit variations only)
-int EnvB; 
-int EnvC; 
+int EnvP;    // Envelope Period
 int StepE; // 1, 0, -1 -- Direction to Step Envelope at end of countdown
 
 int EnvContinue; // Flags from Envelope Type
@@ -70,39 +79,82 @@ int EnvAttack;
 int EnvAlternate;
 int EnvHold;
 
+void PSGSerialize(struct PSGserialized *all)
+{
+    all->PSGBufferSize = PSGBufferSize;
+    memcpy(all->PSGBuffer, PSGBuffer, sizeof(PSGBuffer));
+    all->PSGBufferPos = PSGBufferPos;
+    all->Ticks = Ticks;
+    all->CountA = CountA;
+    all->CountB = CountB;
+    all->CountC = CountC;
+    all->CountN = CountN;
+    all->CountE = CountE;
+    all->OutA = OutA;
+    all->OutB = OutB;
+    all->OutC = OutC;
+    all->OutN = OutN;
+    all->OutE = OutE;
+    all->ChA = ChA;
+    all->ChB = ChB;
+    all->ChC = ChC;
+    all->NoiseP = NoiseP;
+    all->EnvP = EnvP;
+    all->StepE = StepE;
+    all->EnvContinue = EnvContinue;
+    all->EnvAttack = EnvAttack;
+    all->EnvAlternate = EnvAlternate;
+    all->EnvHold = EnvHold;
+}
+
+void PSGUnserialize(const struct PSGserialized *all)
+{
+    PSGBufferSize = all->PSGBufferSize;
+    memcpy(PSGBuffer, all->PSGBuffer, sizeof(PSGBuffer));
+    PSGBufferPos = all->PSGBufferPos;
+    Ticks = all->Ticks;
+    CountA = all->CountA;
+    CountB = all->CountB;
+    CountC = all->CountC;
+    CountN = all->CountN;
+    CountE = all->CountE;
+    OutA = all->OutA;
+    OutB = all->OutB;
+    OutC = all->OutC;
+    OutN = all->OutN;
+    OutE = all->OutE;
+    ChA = all->ChA;
+    ChB = all->ChB;
+    ChC = all->ChC;
+    NoiseP = all->NoiseP;
+    EnvP = all->EnvP;
+    StepE = all->StepE;
+    EnvContinue = all->EnvContinue;
+    EnvAttack = all->EnvAttack;
+    EnvAlternate = all->EnvAlternate;
+    EnvHold = all->EnvHold;
+}
+
 void readRegisters(void)
 {
 	ChA = (Memory[0x01F0] & 0xFF) | ((Memory[0x1F4] & 0x0F)<<8);
 	ChB = (Memory[0x01F1] & 0xFF) | ((Memory[0x1F5] & 0x0F)<<8);
 	ChC = (Memory[0x01F2] & 0xFF) | ((Memory[0x1F6] & 0x0F)<<8);
  
-	VolA = Memory[0x01FB] & 0x0F;
-	VolB = Memory[0x01FC] & 0x0F;
-	VolC = Memory[0x01FD] & 0x0F;
+    ChA = ChA + (0x1000 * (ChA==0)); // a Channel Period value of 0
+    ChB = ChB + (0x1000 * (ChB==0)); // indicates a value of 0x1000
+    ChC = ChC + (0x1000 * (ChC==0));
 
-	NoiseP = (Memory[0x01F9] & 0x1F)<<1;
-	NoiseA = (Memory[0x01F8]>>3) & 0x01;
-	NoiseB = (Memory[0x01F8]>>4) & 0x01;
-	NoiseC = (Memory[0x01F8]>>5) & 0x01;
+    NoiseP = (Memory[0x01F9] & 0x1F)<<1;
 
-	ToneA = Memory[0x01F8] & 0x01;
-	ToneB = (Memory[0x01F8]>>1) & 0x01;
-	ToneC = (Memory[0x01F8]>>2) & 0x01;
+    // a Noise Period of 0 indicates a period of 0x40
+    NoiseP = NoiseP + (0x40 * (NoiseP==0));
 
-	EnvP = ((Memory[0x01F3] & 0xFF) | ((Memory[0x1F7] & 0xFF)<<8))<<1;
-	EnvFlags = Memory[0x01FA] & 0x0F;
-	EnvA = (Memory[0x01FB]>>4) & 0x03;
-	EnvB = (Memory[0x01FC]>>4) & 0x03;
-	EnvC = (Memory[0x01FD]>>4) & 0x03;
+    EnvP = ((Memory[0x01F3] & 0xFF) | ((Memory[0x1F7] & 0xFF)<<8))<<1;
 
-	ChA = ChA + (0x1000 * (ChA==0)); // a Channel Period value of 0 
-	ChB = ChB + (0x1000 * (ChB==0)); // indicates a value of 0x1000
-	ChC = ChC + (0x1000 * (ChC==0));
-	// a Noise Period of 0 indicates a period of 0x40 
-	NoiseP = NoiseP + (0x40 * (NoiseP==0));
-	// an Envelope Period of 0 indicates a period of 0x20000
-	EnvP = EnvP + (0x20000 * (EnvP==0));
-	
+    // an Envelope Period of 0 indicates a period of 0x20000
+    EnvP = EnvP + (0x20000 * (EnvP==0));
+
 	// Envelope Flags
 	EnvContinue = (EnvFlags>>3) & 0x01;
 	EnvAttack = (EnvFlags>>2) & 0x01;
@@ -117,7 +169,7 @@ void PSGInit()
 	OutA = 0; // tone generator outputs
 	OutB = 0;
 	OutC = 0;
-	OutN = 0x14000; // noise output
+	OutN = 0x10004; // noise output
 	OutE = 0; // envelope output
 	CountA = 0; // tone generator countdowns
 	CountB = 0;
@@ -172,9 +224,9 @@ void PSGTick(int ticks) // adds 1 sound sample per 4 cpu cycles to the buffer
 
 	Ticks = Ticks + ticks;
 
-	while(Ticks > 3)
+	while(Ticks >= 4)
 	{
-		Ticks = Ticks - 4;
+		Ticks -= 4;
 
 		CountA--;
 		CountB--;
@@ -246,9 +298,9 @@ void PSGTick(int ticks) // adds 1 sound sample per 4 cpu cycles to the buffer
 		c = (NoiseC | (OutN & 1)) & (ToneC | OutC);
 
 		// Adjust amplitude (Volume / Envelope)
-		a = a * ( (Volume[VolA] * (EnvA==0)) | (Volume[OutE] * (EnvA!=0)) );
-		b = b * ( (Volume[VolB] * (EnvB==0)) | (Volume[OutE] * (EnvB!=0)) );
-		c = c * ( (Volume[VolC] * (EnvC==0)) | (Volume[OutE] * (EnvC!=0)) );
+		a = a * ( (Volume[VolA] * (EnvA==0)) | (Volume[OutE >> Envelope_Shift[EnvA]]) );
+		b = b * ( (Volume[VolB] * (EnvB==0)) | (Volume[OutE >> Envelope_Shift[EnvB]]) );
+		c = c * ( (Volume[VolC] * (EnvC==0)) | (Volume[OutE >> Envelope_Shift[EnvC]]) );
 
 		sample = a + b + c;
 

--- a/src/psg.h
+++ b/src/psg.h
@@ -23,6 +23,43 @@ extern int16_t PSGBuffer[7467]; // 14934 cpu cycles/frame ; 3733.5 psg cycles/fr
 extern int PSGBufferPos; // points to next location in output buffer
 extern int PSGBufferSize;
 
+struct PSGserialized {
+    int PSGBufferSize;
+    int16_t PSGBuffer[7467];
+    int PSGBufferPos;
+    
+    int Ticks; // CPU cycles not yet processed
+    
+    int CountA; // countdowns for tone generators
+    int CountB; // used to modulate square-wave
+    int CountC; // according to Channel Period
+    int CountN; // countdown for noise generator
+    int CountE; // countdown for envelope generator
+    
+    int OutA; // outputs for each tone generator
+    int OutB;
+    int OutC;
+    int OutN;  // Noise generator output
+    int OutE;  // Envelope generator output
+    
+    int ChA; // Channel Period from PSG Registers
+    int ChB;
+    int ChC;
+    
+    int NoiseP; // Noise Period
+    
+    int EnvP;    // Envelope Period
+    int StepE; // 1, 0, -1 -- Direction to Step Envelope at end of countdown
+    
+    int EnvContinue; // Flags from Envelope Type
+    int EnvAttack;
+    int EnvAlternate;
+    int EnvHold;
+};
+
+void PSGSerialize(struct PSGserialized *);
+void PSGUnserialize(const struct PSGserialized *);
+
 void PSGInit(void); 
 void PSGFrame(void); // Notify New Frame
 void PSGTick(int ticks); // ticks PSG some number of cpu cycles 

--- a/src/stic.c
+++ b/src/stic.c
@@ -136,6 +136,7 @@ void STICSerialize(struct STICserialized *all)
     all->CSP = CSP;
     memcpy(all->fgcard, fgcard, sizeof(fgcard));
     memcpy(all->bgcard, bgcard, sizeof(bgcard));
+    memcpy(all->frame, frame, sizeof(frame));
 }
 
 void STICUnserialize(const struct STICserialized *all)
@@ -154,6 +155,7 @@ void STICUnserialize(const struct STICserialized *all)
     CSP = all->CSP;
     memcpy(fgcard, all->fgcard, sizeof(fgcard));
     memcpy(bgcard, all->bgcard, sizeof(bgcard));
+    memcpy(frame, all->frame, sizeof(frame));
 }
 
 void STICReset(void)

--- a/src/stic.h
+++ b/src/stic.h
@@ -51,6 +51,8 @@ struct STICserialized {
     unsigned int CSP;
     unsigned int fgcard[20];
     unsigned int bgcard[20];
+
+    unsigned int frame[352*224];
 };
 
 void STICSerialize(struct STICserialized *);


### PR DESCRIPTION
* Serialization now can work anytime (added video frame to state and PSG state)
* Rewind tested and working.
* PSG now compatible with Intellivision AY-3-8914 (it was AY-3-8910 so envelope volumes were wrong)
* RetroArch restart function now works (before the Reset function called memory_init so it erased the game and made the Intellivision to HALT)
* Removed several global variables used in the PSG module.
