### PR TITLE
Add support for Core Options - add core option to select default P1 controller as Left or Right

### DIFF
--- a/src/controller.c
+++ b/src/controller.c
@@ -69,6 +69,7 @@ int cursor[4] = { 0, 0, 0, 0 }; // mini keypad cursor (button row/column p0x,p0y
 
 int getQuickKeypadState(int player);
 
+// This function is no longer directly called, the default controller is managed via core option now
 void controllerInit()
 {
 	controllerSwap = 0;

--- a/src/controller.c
+++ b/src/controller.c
@@ -67,6 +67,10 @@ int keypadStates[12]={ K_1, K_2, K_3, K_4, K_5, K_6, K_7, K_8, K_9, K_C, K_0, K_
 
 int cursor[4] = { 0, 0, 0, 0 }; // mini keypad cursor (button row/column p0x,p0y p1x,p1y)
 
+// flag to determine if keypad buttons are mapped to individual controller buttons
+// such as L/R and X rather than the default configuration
+int keypadButtonMode[2] = { 0, 0 };
+
 int getQuickKeypadState(int player);
 
 // This function is no longer directly called, the default controller is managed via core option now
@@ -110,7 +114,20 @@ int getControllerState(int joypad[], int player)
 	if(joypad[4]!=0) { state |= B_LEFT; } // 0x9F - Button Left
 	if(joypad[5]!=0) { state |= B_RIGHT; } // 0x3F - Button Right
 
-	if(joypad[6]!=0) { state |= getQuickKeypadState(player); }
+	// Default configuration maps X to the last used keypad button
+	if(!keypadButtonMode[player])
+	{
+		if(joypad[6]!=0) { state |= getQuickKeypadState(player); }
+	}
+	else
+	{
+		// In Keypad mode the numpad keys that don't correspond to the up/down/left/right axes on the Rt Analog
+		// are mapped to buttons directly so they can be accessed/remapped via the RetroArch controller interface
+		if(joypad[6]!=0) { state |= K_1; } // 0x81 - Keypad 1
+		if(joypad[9]!=0) { state |= K_9; } // 0x24 - Keypad 9
+		if(joypad[10]!=0) { state |= K_3; } // 0x21 - Keypad 3
+		if(joypad[11]!=0) { state |= K_7; } // 0x84 - Keypad 7
+	}
 
 	/* Analog Controls for 16-way disc control */
 

--- a/src/controller.h
+++ b/src/controller.h
@@ -22,6 +22,8 @@ extern int controllerSwap;
 
 extern int keypadStates[];
 
+extern int keypadButtonMode[];
+
 void controllerInit(void);
 
 int getControllerState(int joypad[], int player);

--- a/src/libretro.c
+++ b/src/libretro.c
@@ -58,10 +58,10 @@ struct retro_game_geometry Geometry;
 
 static bool libretro_supports_bitmasks = false;
 
-int joypad0[18]; // joypad 0 state
-int joypad1[18]; // joypad 1 state
-int joypre0[18]; // joypad 0 previous state
-int joypre1[18]; // joypad 1 previous state
+int joypad0[20]; // joypad 0 state
+int joypad1[20]; // joypad 1 state
+int joypre0[20]; // joypad 0 previous state
+int joypre1[20]; // joypad 1 previous state
 
 bool paused = false;
 
@@ -144,7 +144,7 @@ static void update_input(void)
 
 	InputPoll();
 
-	for(i = 0; i < 18; i++) // Copy previous state 
+	for(i = 0; i < 20; i++) // Copy previous state 
 	{
 		joypre0[i] = joypad0[i];
 		joypre1[i] = joypad1[i];

--- a/src/libretro.c
+++ b/src/libretro.c
@@ -306,29 +306,49 @@ static void update_input(void)
 	joypad0[2] = joypad_bits[0] & (1 << RETRO_DEVICE_ID_JOYPAD_LEFT)   ? 1 : 0;
 	joypad0[3] = joypad_bits[0] & (1 << RETRO_DEVICE_ID_JOYPAD_RIGHT)  ? 1 : 0;
 
-	joypad0[4] = joypad_bits[0] & (1 << RETRO_DEVICE_ID_JOYPAD_A)      ? 1 : 0;
-	joypad0[5] = joypad_bits[0] & (1 << RETRO_DEVICE_ID_JOYPAD_B)      ? 1 : 0;
-	joypad0[6] = joypad_bits[0] & (1 << RETRO_DEVICE_ID_JOYPAD_X)      ? 1 : 0;
-	joypad0[7] = joypad_bits[0] & (1 << RETRO_DEVICE_ID_JOYPAD_Y)      ? 1 : 0;
-
-	joypad0[8] = joypad_bits[0] & (1 << RETRO_DEVICE_ID_JOYPAD_START)  ? 1 : 0;
-	joypad0[9] = joypad_bits[0] & (1 << RETRO_DEVICE_ID_JOYPAD_SELECT) ? 1 : 0;
-
-	joypad0[10] = joypad_bits[0] & (1 << RETRO_DEVICE_ID_JOYPAD_L)     ? 1 : 0;
-	joypad0[11] = joypad_bits[0] & (1 << RETRO_DEVICE_ID_JOYPAD_R)     ? 1 : 0;
-	joypad0[12] = joypad_bits[0] & (1 << RETRO_DEVICE_ID_JOYPAD_L2)    ? 1 : 0;
-	joypad0[13] = joypad_bits[0] & (1 << RETRO_DEVICE_ID_JOYPAD_R2)    ? 1 : 0;
-	joypad0[18] = joypad_bits[0] & (1 << RETRO_DEVICE_ID_JOYPAD_L3)    ? 1 : 0;
-	joypad0[19] = joypad_bits[0] & (1 << RETRO_DEVICE_ID_JOYPAD_R3)    ? 1 : 0;
-
 	joypad0[14] = InputState(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X);
 	joypad0[15] = InputState(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y);
 
-	// If we have enabled the Dual Controller option, the Keypad right stick inputs will come from Controller 2
+	// If we have enabled the Dual Controller option, the keypad and action buttons will come from the other controller
 	if (!dual_controllers)
 	{
+		joypad0[4] = joypad_bits[0] & (1 << RETRO_DEVICE_ID_JOYPAD_A)      ? 1 : 0;
+		joypad0[5] = joypad_bits[0] & (1 << RETRO_DEVICE_ID_JOYPAD_B)      ? 1 : 0;
+		joypad0[6] = joypad_bits[0] & (1 << RETRO_DEVICE_ID_JOYPAD_X)      ? 1 : 0;
+		joypad0[7] = joypad_bits[0] & (1 << RETRO_DEVICE_ID_JOYPAD_Y)      ? 1 : 0;
+
+		joypad0[8] = joypad_bits[0] & (1 << RETRO_DEVICE_ID_JOYPAD_START)  ? 1 : 0;
+		joypad0[9] = joypad_bits[0] & (1 << RETRO_DEVICE_ID_JOYPAD_SELECT) ? 1 : 0;
+
+		joypad0[10] = joypad_bits[0] & (1 << RETRO_DEVICE_ID_JOYPAD_L)     ? 1 : 0;
+		joypad0[11] = joypad_bits[0] & (1 << RETRO_DEVICE_ID_JOYPAD_R)     ? 1 : 0;
+		joypad0[12] = joypad_bits[0] & (1 << RETRO_DEVICE_ID_JOYPAD_L2)    ? 1 : 0;
+		joypad0[13] = joypad_bits[0] & (1 << RETRO_DEVICE_ID_JOYPAD_R2)    ? 1 : 0;
+		joypad0[18] = joypad_bits[0] & (1 << RETRO_DEVICE_ID_JOYPAD_L3)    ? 1 : 0;
+		joypad0[19] = joypad_bits[0] & (1 << RETRO_DEVICE_ID_JOYPAD_R3)    ? 1 : 0;
+
 		joypad0[16] = InputState(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X);
 		joypad0[17] = InputState(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y);
+	}
+	else
+	{
+		joypad0[4] = joypad_bits[1] & (1 << RETRO_DEVICE_ID_JOYPAD_A)      ? 1 : 0;
+		joypad0[5] = joypad_bits[1] & (1 << RETRO_DEVICE_ID_JOYPAD_B)      ? 1 : 0;
+		joypad0[6] = joypad_bits[1] & (1 << RETRO_DEVICE_ID_JOYPAD_X)      ? 1 : 0;
+		joypad0[7] = joypad_bits[1] & (1 << RETRO_DEVICE_ID_JOYPAD_Y)      ? 1 : 0;
+
+		joypad0[8] = joypad_bits[1] & (1 << RETRO_DEVICE_ID_JOYPAD_START)  ? 1 : 0;
+		joypad0[9] = joypad_bits[1] & (1 << RETRO_DEVICE_ID_JOYPAD_SELECT) ? 1 : 0;
+
+		joypad0[10] = joypad_bits[1] & (1 << RETRO_DEVICE_ID_JOYPAD_L)     ? 1 : 0;
+		joypad0[11] = joypad_bits[1] & (1 << RETRO_DEVICE_ID_JOYPAD_R)     ? 1 : 0;
+		joypad0[12] = joypad_bits[1] & (1 << RETRO_DEVICE_ID_JOYPAD_L2)    ? 1 : 0;
+		joypad0[13] = joypad_bits[1] & (1 << RETRO_DEVICE_ID_JOYPAD_R2)    ? 1 : 0;
+		joypad0[18] = joypad_bits[1] & (1 << RETRO_DEVICE_ID_JOYPAD_L3)    ? 1 : 0;
+		joypad0[19] = joypad_bits[1] & (1 << RETRO_DEVICE_ID_JOYPAD_R3)    ? 1 : 0;
+
+		joypad0[16] = InputState(1, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X);
+		joypad0[17] = InputState(1, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y);
 	}
 
 	/* JoyPad 1 */
@@ -337,32 +357,47 @@ static void update_input(void)
 	joypad1[2] = joypad_bits[1] & (1 << RETRO_DEVICE_ID_JOYPAD_LEFT)   ? 1 : 0;
 	joypad1[3] = joypad_bits[1] & (1 << RETRO_DEVICE_ID_JOYPAD_RIGHT)  ? 1 : 0;
 
-	joypad1[4] = joypad_bits[1] & (1 << RETRO_DEVICE_ID_JOYPAD_A)      ? 1 : 0;
-	joypad1[5] = joypad_bits[1] & (1 << RETRO_DEVICE_ID_JOYPAD_B)      ? 1 : 0;
-	joypad1[6] = joypad_bits[1] & (1 << RETRO_DEVICE_ID_JOYPAD_X)      ? 1 : 0;
-	joypad1[7] = joypad_bits[1] & (1 << RETRO_DEVICE_ID_JOYPAD_Y)      ? 1 : 0;
-
-	joypad1[8] = joypad_bits[1] & (1 << RETRO_DEVICE_ID_JOYPAD_START)  ? 1 : 0;
-	joypad1[9] = joypad_bits[1] & (1 << RETRO_DEVICE_ID_JOYPAD_SELECT) ? 1 : 0;
-
-	joypad1[10] = joypad_bits[1] & (1 << RETRO_DEVICE_ID_JOYPAD_L)     ? 1 : 0;
-	joypad1[11] = joypad_bits[1] & (1 << RETRO_DEVICE_ID_JOYPAD_R)     ? 1 : 0;
-	joypad1[12] = joypad_bits[1] & (1 << RETRO_DEVICE_ID_JOYPAD_L2)    ? 1 : 0;
-	joypad1[13] = joypad_bits[1] & (1 << RETRO_DEVICE_ID_JOYPAD_R2)    ? 1 : 0;
-	joypad1[18] = joypad_bits[1] & (1 << RETRO_DEVICE_ID_JOYPAD_L3)    ? 1 : 0;
-	joypad1[19] = joypad_bits[1] & (1 << RETRO_DEVICE_ID_JOYPAD_R3)    ? 1 : 0;
-
 	joypad1[14] = InputState(1, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X);
 	joypad1[15] = InputState(1, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y);
 
-	// If we have enabled the Dual Controller option, the right analog will be routed to Controller 1
+	// If we have enabled the Dual Controller option, the keypad and action buttons will come from the other controller
 	if (!dual_controllers)
 	{
+		joypad1[4] = joypad_bits[1] & (1 << RETRO_DEVICE_ID_JOYPAD_A)      ? 1 : 0;
+		joypad1[5] = joypad_bits[1] & (1 << RETRO_DEVICE_ID_JOYPAD_B)      ? 1 : 0;
+		joypad1[6] = joypad_bits[1] & (1 << RETRO_DEVICE_ID_JOYPAD_X)      ? 1 : 0;
+		joypad1[7] = joypad_bits[1] & (1 << RETRO_DEVICE_ID_JOYPAD_Y)      ? 1 : 0;
+
+		joypad1[8] = joypad_bits[1] & (1 << RETRO_DEVICE_ID_JOYPAD_START)  ? 1 : 0;
+		joypad1[9] = joypad_bits[1] & (1 << RETRO_DEVICE_ID_JOYPAD_SELECT) ? 1 : 0;
+
+		joypad1[10] = joypad_bits[1] & (1 << RETRO_DEVICE_ID_JOYPAD_L)     ? 1 : 0;
+		joypad1[11] = joypad_bits[1] & (1 << RETRO_DEVICE_ID_JOYPAD_R)     ? 1 : 0;
+		joypad1[12] = joypad_bits[1] & (1 << RETRO_DEVICE_ID_JOYPAD_L2)    ? 1 : 0;
+		joypad1[13] = joypad_bits[1] & (1 << RETRO_DEVICE_ID_JOYPAD_R2)    ? 1 : 0;
+		joypad1[18] = joypad_bits[1] & (1 << RETRO_DEVICE_ID_JOYPAD_L3)    ? 1 : 0;
+		joypad1[19] = joypad_bits[1] & (1 << RETRO_DEVICE_ID_JOYPAD_R3)    ? 1 : 0;
+
 		joypad1[16] = InputState(1, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X);
 		joypad1[17] = InputState(1, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y);
 	}
 	else
 	{
+		joypad1[4] = joypad_bits[0] & (1 << RETRO_DEVICE_ID_JOYPAD_A)      ? 1 : 0;
+		joypad1[5] = joypad_bits[0] & (1 << RETRO_DEVICE_ID_JOYPAD_B)      ? 1 : 0;
+		joypad1[6] = joypad_bits[0] & (1 << RETRO_DEVICE_ID_JOYPAD_X)      ? 1 : 0;
+		joypad1[7] = joypad_bits[0] & (1 << RETRO_DEVICE_ID_JOYPAD_Y)      ? 1 : 0;
+
+		joypad1[8] = joypad_bits[0] & (1 << RETRO_DEVICE_ID_JOYPAD_START)  ? 1 : 0;
+		joypad1[9] = joypad_bits[0] & (1 << RETRO_DEVICE_ID_JOYPAD_SELECT) ? 1 : 0;
+
+		joypad1[10] = joypad_bits[0] & (1 << RETRO_DEVICE_ID_JOYPAD_L)     ? 1 : 0;
+		joypad1[11] = joypad_bits[0] & (1 << RETRO_DEVICE_ID_JOYPAD_R)     ? 1 : 0;
+		joypad1[12] = joypad_bits[0] & (1 << RETRO_DEVICE_ID_JOYPAD_L2)    ? 1 : 0;
+		joypad1[13] = joypad_bits[0] & (1 << RETRO_DEVICE_ID_JOYPAD_R2)    ? 1 : 0;
+		joypad1[18] = joypad_bits[0] & (1 << RETRO_DEVICE_ID_JOYPAD_L3)    ? 1 : 0;
+		joypad1[19] = joypad_bits[0] & (1 << RETRO_DEVICE_ID_JOYPAD_R3)    ? 1 : 0;
+
 		joypad1[16] = InputState(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X);
 		joypad1[17] = InputState(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y);
 	}
@@ -515,6 +550,7 @@ void retro_run(void)
 	else
 	{
 		// Only show the OSD keypad if the controller type is the default type - otherwise L/R are utilized as a normal input button
+		// @todo need to fix this to handle the dual controller option so it works as expected even when this option is enabled
 		if ((joypad0[10] | joypad0[11]) && !keypadButtonMode[0]) // left/right shoulder down
 		{
 			showKeypad0 = true;

--- a/src/libretro.c
+++ b/src/libretro.c
@@ -47,6 +47,7 @@ retro_audio_sample_t Audio;
 retro_audio_sample_batch_t AudioBatch;
 retro_input_poll_t InputPoll;
 retro_input_state_t InputState;
+retro_log_printf_t log_cb;
 
 void retro_set_video_refresh(retro_video_refresh_t fn) { Video = fn; }
 void retro_set_audio_sample(retro_audio_sample_t fn) { Audio = fn; }
@@ -229,6 +230,7 @@ void retro_init(void)
 	char execPath[PATH_MAX_LENGTH];
 	char gromPath[PATH_MAX_LENGTH];
 	struct retro_keyboard_callback kb = { Keyboard };
+        struct retro_log_callback log;
 
 	// controller descriptors
 	struct retro_input_descriptor desc[] = {
@@ -272,6 +274,11 @@ void retro_init(void)
 
 		{ 0 },
 	};
+
+	if (Environ(RETRO_ENVIRONMENT_GET_LOG_INTERFACE, &log))
+		log_cb = log.log;
+	else
+		log_cb = NULL;
 
 	// init buffers, structs
 	memset(frame, 0, frameSize);
@@ -488,7 +495,6 @@ void retro_get_system_av_info(struct retro_system_av_info *info)
 
 	Environ(RETRO_ENVIRONMENT_SET_PIXEL_FORMAT, &pixelformat);
 }
-
 
 void retro_deinit(void)
 {

--- a/src/libretro.c
+++ b/src/libretro.c
@@ -20,6 +20,7 @@
 #include <stdint.h>
 #include <string.h>
 #include "libretro.h"
+#include "libretro_core_options.h"
 #include <file/file_path.h>
 #include <retro_miscellaneous.h>
 
@@ -45,7 +46,6 @@ retro_audio_sample_batch_t AudioBatch;
 retro_input_poll_t InputPoll;
 retro_input_state_t InputState;
 
-void retro_set_environment(retro_environment_t fn) { Environ = fn; }
 void retro_set_video_refresh(retro_video_refresh_t fn) { Video = fn; }
 void retro_set_audio_sample(retro_audio_sample_t fn) { Audio = fn; }
 void retro_set_audio_sample_batch(retro_audio_sample_batch_t fn) { AudioBatch = fn; }
@@ -112,6 +112,33 @@ static void Keyboard(bool down, unsigned keycode,
 	}
 }
 
+static void check_variables(bool first_run)
+{
+	struct retro_variable var = {0};
+
+	if (first_run)
+	{
+		var.key   = "default_p1_controller";
+		var.value = NULL;
+
+		// by default input 0 maps to Right Controller (0x1FE)
+		// and input 1 maps to Left Controller (0x1FF)
+		controllerSwap = 0;
+
+		if (Environ(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+		{
+			if (strcmp(var.value, "left") == 0)
+				controllerSwap = 1;
+		}
+	}
+}
+
+void retro_set_environment(retro_environment_t fn)
+{
+	Environ = fn;
+	libretro_set_core_options(Environ);
+}
+
 void retro_init(void)
 {
 	char execPath[PATH_MAX_LENGTH];
@@ -165,9 +192,6 @@ void retro_init(void)
 	memset(frame, 0, frameSize);
 	OSD_setDisplay(frame, MaxWidth, MaxHeight);
 
-	// setup controller swap
-	controllerInit();
-
 	Environ(RETRO_ENVIRONMENT_SET_INPUT_DESCRIPTORS, desc);
 
 	// reset console
@@ -191,6 +215,7 @@ void retro_init(void)
 
 bool retro_load_game(const struct retro_game_info *info)
 {
+	check_variables(true);
 	LoadGame(info->path);
 	return true;
 }
@@ -205,6 +230,10 @@ void retro_run(void)
 	int c, i, j, k, l;
 	int showKeypad0 = false;
 	int showKeypad1 = false;
+
+	bool options_updated  = false;
+	if (Environ(RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE, &options_updated) && options_updated)
+		check_variables(false);
 
 	InputPoll();
 

--- a/src/libretro.c
+++ b/src/libretro.c
@@ -264,7 +264,7 @@ void retro_run(void)
 	joypad1[16] = InputState(1, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X);
 	joypad1[17] = InputState(1, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y);
 	joypad1[18] = InputState(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L3);
-	joypad1[18] = InputState(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R3);
+	joypad1[19] = InputState(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R3);
 
 	// Pause
 	if((joypad0[8]==1 && joypre0[8]==0) || (joypad1[8]==1 && joypre1[8]==0))

--- a/src/libretro_core_options.h
+++ b/src/libretro_core_options.h
@@ -1,0 +1,261 @@
+#ifndef LIBRETRO_CORE_OPTIONS_H__
+#define LIBRETRO_CORE_OPTIONS_H__
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <libretro.h>
+#include <retro_inline.h>
+
+#ifndef HAVE_NO_LANGEXTRA
+#include "libretro_core_options_intl.h"
+#endif
+
+/*
+ ********************************
+ * VERSION: 1.3
+ ********************************
+ *
+ * - 1.3: Move translations to libretro_core_options_intl.h
+ *        - libretro_core_options_intl.h includes BOM and utf-8
+ *          fix for MSVC 2010-2013
+ *        - Added HAVE_NO_LANGEXTRA flag to disable translations
+ *          on platforms/compilers without BOM support
+ * - 1.2: Use core options v1 interface when
+ *        RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION is >= 1
+ *        (previously required RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION == 1)
+ * - 1.1: Support generation of core options v0 retro_core_option_value
+ *        arrays containing options with a single value
+ * - 1.0: First commit
+*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ ********************************
+ * Core Option Definitions
+ ********************************
+*/
+
+/* RETRO_LANGUAGE_ENGLISH */
+
+/* Default language:
+ * - All other languages must include the same keys and values
+ * - Will be used as a fallback in the event that frontend language
+ *   is not available
+ * - Will be used as a fallback for any missing entries in
+ *   frontend language definition */
+
+struct retro_core_option_definition option_defs_us[] = {
+   {
+      "default_p1_controller",
+      "Default Player 1 Controller (Restart)",
+      "Specify whether the Left or Right Controller is set to Player 1 as the default.",
+      {
+         { "left", "Left" },
+         { "right", "Right" },
+         { NULL, NULL },
+      },
+      "right"
+   },
+   { NULL, NULL, NULL, {{0}}, NULL },
+};
+
+/*
+ ********************************
+ * Language Mapping
+ ********************************
+*/
+
+#ifndef HAVE_NO_LANGEXTRA
+struct retro_core_option_definition *option_defs_intl[RETRO_LANGUAGE_LAST] = {
+   option_defs_us, /* RETRO_LANGUAGE_ENGLISH */
+   NULL,           /* RETRO_LANGUAGE_JAPANESE */
+   NULL,           /* RETRO_LANGUAGE_FRENCH */
+   NULL,           /* RETRO_LANGUAGE_SPANISH */
+   NULL,           /* RETRO_LANGUAGE_GERMAN */
+   NULL,           /* RETRO_LANGUAGE_ITALIAN */
+   NULL,           /* RETRO_LANGUAGE_DUTCH */
+   NULL,           /* RETRO_LANGUAGE_PORTUGUESE_BRAZIL */
+   NULL,           /* RETRO_LANGUAGE_PORTUGUESE_PORTUGAL */
+   NULL,           /* RETRO_LANGUAGE_RUSSIAN */
+   NULL,           /* RETRO_LANGUAGE_KOREAN */
+   NULL,           /* RETRO_LANGUAGE_CHINESE_TRADITIONAL */
+   NULL,           /* RETRO_LANGUAGE_CHINESE_SIMPLIFIED */
+   NULL,           /* RETRO_LANGUAGE_ESPERANTO */
+   NULL,           /* RETRO_LANGUAGE_POLISH */
+   NULL,           /* RETRO_LANGUAGE_VIETNAMESE */
+   NULL,           /* RETRO_LANGUAGE_ARABIC */
+   NULL,           /* RETRO_LANGUAGE_GREEK */
+   NULL,           /* RETRO_LANGUAGE_TURKISH */
+   NULL,           /* RETRO_LANGUAGE_SLOVAK */
+   NULL,           /* RETRO_LANGUAGE_PERSIAN */
+   NULL,           /* RETRO_LANGUAGE_HEBREW */
+   NULL,           /* RETRO_LANGUAGE_ASTURIAN */
+   NULL,           /* RETRO_LANGUAGE_FINNISH */
+
+};
+#endif
+
+/*
+ ********************************
+ * Functions
+ ********************************
+*/
+
+/* Handles configuration/setting of core options.
+ * Should be called as early as possible - ideally inside
+ * retro_set_environment(), and no later than retro_load_game()
+ * > We place the function body in the header to avoid the
+ *   necessity of adding more .c files (i.e. want this to
+ *   be as painless as possible for core devs)
+ */
+
+static INLINE void libretro_set_core_options(retro_environment_t environ_cb)
+{
+   unsigned version = 0;
+
+   if (!environ_cb)
+      return;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION, &version) && (version >= 1))
+   {
+#ifndef HAVE_NO_LANGEXTRA
+      struct retro_core_options_intl core_options_intl;
+      unsigned language = 0;
+
+      core_options_intl.us    = option_defs_us;
+      core_options_intl.local = NULL;
+
+      if (environ_cb(RETRO_ENVIRONMENT_GET_LANGUAGE, &language) &&
+          (language < RETRO_LANGUAGE_LAST) && (language != RETRO_LANGUAGE_ENGLISH))
+         core_options_intl.local = option_defs_intl[language];
+
+      environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_INTL, &core_options_intl);
+#else
+      environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS, &option_defs_us);
+#endif
+   }
+   else
+   {
+      size_t i;
+      size_t num_options               = 0;
+      struct retro_variable *variables = NULL;
+      char **values_buf                = NULL;
+
+      /* Determine number of options */
+      for (;;)
+      {
+         if (!option_defs_us[num_options].key)
+            break;
+         num_options++;
+      }
+
+      /* Allocate arrays */
+      variables  = (struct retro_variable *)calloc(num_options + 1, sizeof(struct retro_variable));
+      values_buf = (char **)calloc(num_options, sizeof(char *));
+
+      if (!variables || !values_buf)
+         goto error;
+
+      /* Copy parameters from option_defs_us array */
+      for (i = 0; i < num_options; i++)
+      {
+         const char *key                        = option_defs_us[i].key;
+         const char *desc                       = option_defs_us[i].desc;
+         const char *default_value              = option_defs_us[i].default_value;
+         struct retro_core_option_value *values = option_defs_us[i].values;
+         size_t buf_len                         = 3;
+         size_t default_index                   = 0;
+
+         values_buf[i] = NULL;
+
+         if (desc)
+         {
+            size_t num_values = 0;
+
+            /* Determine number of values */
+            for (;;)
+            {
+               if (!values[num_values].value)
+                  break;
+
+               /* Check if this is the default value */
+               if (default_value)
+                  if (strcmp(values[num_values].value, default_value) == 0)
+                     default_index = num_values;
+
+               buf_len += strlen(values[num_values].value);
+               num_values++;
+            }
+
+            /* Build values string */
+            if (num_values > 0)
+            {
+               size_t j;
+
+               buf_len += num_values - 1;
+               buf_len += strlen(desc);
+
+               values_buf[i] = (char *)calloc(buf_len, sizeof(char));
+               if (!values_buf[i])
+                  goto error;
+
+               strcpy(values_buf[i], desc);
+               strcat(values_buf[i], "; ");
+
+               /* Default value goes first */
+               strcat(values_buf[i], values[default_index].value);
+
+               /* Add remaining values */
+               for (j = 0; j < num_values; j++)
+               {
+                  if (j != default_index)
+                  {
+                     strcat(values_buf[i], "|");
+                     strcat(values_buf[i], values[j].value);
+                  }
+               }
+            }
+         }
+
+         variables[i].key   = key;
+         variables[i].value = values_buf[i];
+      }
+
+      /* Set variables */
+      environ_cb(RETRO_ENVIRONMENT_SET_VARIABLES, variables);
+
+error:
+
+      /* Clean up */
+      if (values_buf)
+      {
+         for (i = 0; i < num_options; i++)
+         {
+            if (values_buf[i])
+            {
+               free(values_buf[i]);
+               values_buf[i] = NULL;
+            }
+         }
+
+         free(values_buf);
+         values_buf = NULL;
+      }
+
+      if (variables)
+      {
+         free(variables);
+         variables = NULL;
+      }
+   }
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/libretro_core_options.h
+++ b/src/libretro_core_options.h
@@ -60,6 +60,17 @@ struct retro_core_option_definition option_defs_us[] = {
       },
       "right"
    },
+   {
+      "dual_controller_enabled",
+      "Enable Dual Controllers",
+      "Maps the Right Analog Keypad Buttons from Controller 2 to Controller 1 Right Analog. This allows games such as Night Stalker and Tron Deadly Discs to support moving and shooting simultaneously.",
+      {
+         { "enabled", "Enabled" },
+         { "disabled", "Disabled" },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
    { NULL, NULL, NULL, {{0}}, NULL },
 };
 

--- a/src/libretro_core_options.h
+++ b/src/libretro_core_options.h
@@ -63,7 +63,7 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "dual_controller_enabled",
       "Enable Dual Controllers",
-      "Maps the Right Analog Keypad Buttons from Controller 2 to Controller 1 Right Analog. This allows games such as Night Stalker and Tron Deadly Discs to support moving and shooting simultaneously.",
+      "Maps the Action and Keypad Buttons from Controller 2 to Controller 1 and vice versa. This allows games such as Night Stalker and Tron Deadly Discs to support moving and shooting simultaneously.",
       {
          { "enabled", "Enabled" },
          { "disabled", "Disabled" },

--- a/src/libretro_core_options_intl.h
+++ b/src/libretro_core_options_intl.h
@@ -1,0 +1,90 @@
+#ifndef LIBRETRO_CORE_OPTIONS_INTL_H__
+#define LIBRETRO_CORE_OPTIONS_INTL_H__
+
+#if defined(_MSC_VER) && (_MSC_VER >= 1500 && _MSC_VER < 1900)
+/* https://support.microsoft.com/en-us/kb/980263 */
+#pragma execution_character_set("utf-8")
+#pragma warning(disable:4566)
+#endif
+
+#include <libretro.h>
+
+/*
+ ********************************
+ * VERSION: 1.3
+ ********************************
+ *
+ * - 1.3: Move translations to libretro_core_options_intl.h
+ *        - libretro_core_options_intl.h includes BOM and utf-8
+ *          fix for MSVC 2010-2013
+ *        - Added HAVE_NO_LANGEXTRA flag to disable translations
+ *          on platforms/compilers without BOM support
+ * - 1.2: Use core options v1 interface when
+ *        RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION is >= 1
+ *        (previously required RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION == 1)
+ * - 1.1: Support generation of core options v0 retro_core_option_value
+ *        arrays containing options with a single value
+ * - 1.0: First commit
+*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ ********************************
+ * Core Option Definitions
+ ********************************
+*/
+
+/* RETRO_LANGUAGE_JAPANESE */
+
+/* RETRO_LANGUAGE_FRENCH */
+
+/* RETRO_LANGUAGE_SPANISH */
+
+/* RETRO_LANGUAGE_GERMAN */
+
+/* RETRO_LANGUAGE_ITALIAN */
+
+/* RETRO_LANGUAGE_DUTCH */
+
+/* RETRO_LANGUAGE_PORTUGUESE_BRAZIL */
+
+/* RETRO_LANGUAGE_PORTUGUESE_PORTUGAL */
+
+/* RETRO_LANGUAGE_RUSSIAN */
+
+/* RETRO_LANGUAGE_KOREAN */
+
+/* RETRO_LANGUAGE_CHINESE_TRADITIONAL */
+
+/* RETRO_LANGUAGE_CHINESE_SIMPLIFIED */
+
+/* RETRO_LANGUAGE_ESPERANTO */
+
+/* RETRO_LANGUAGE_POLISH */
+
+/* RETRO_LANGUAGE_VIETNAMESE */
+
+/* RETRO_LANGUAGE_ARABIC */
+
+/* RETRO_LANGUAGE_GREEK */
+
+/* RETRO_LANGUAGE_TURKISH */
+
+/* RETRO_LANGUAGE_SLOVAK */
+
+/* RETRO_LANGUAGE_PERSIAN */
+
+/* RETRO_LANGUAGE_HEBREW */
+
+/* RETRO_LANGUAGE_ASTURIAN */
+
+/* RETRO_LANGUAGE_FINNISH */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
As some games require using the Left vs. the Right controller for P1, this core option will allow setting the default controller, so per game options can be used for games like Zaxxon that use the Left controller as P1.

Since there is also a button mapped to swapping controllers this will only set the default when first initializing so it won't create conflicts with the toggle command.