### PR TITLE
Makefile fix to enable build for "unix-armv7-hardfloat-neon"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ ifeq ($(STATIC_LINKING),1)
 EXT := a
 endif
 
-ifeq ($(platform), unix)
+ifneq (,$(findstring unix,$(platform)))
 	EXT ?= so
 	TARGET := $(TARGET_NAME)_libretro.$(EXT)
 	fpic := -fPIC


### PR DESCRIPTION
Compilation was not successful for "unix-armv7-hardfloat-neon" (one of the options in libretro-super build scripts).